### PR TITLE
Issue5 mb logging api test coverage

### DIFF
--- a/mb-digest-api/routes/routes.js
+++ b/mb-digest-api/routes/routes.js
@@ -1,6 +1,8 @@
 /**
  * Application routes module. Routes define which objects to instantiate as
  * a result.
+ *
+ * Mounted on "/api" with: app.use('/api', routes);
  */
 
 module.exports = (function() {

--- a/mb-logging-api/.gitignore
+++ b/mb-logging-api/.gitignore
@@ -1,8 +1,8 @@
 # Ststtem files
 .DS_Store
 
-# Ignore config files
-config/
+# Ignore config file
+config/mb_config.json
 
 # Libraries
 node_modules/

--- a/mb-logging-api/README.md
+++ b/mb-logging-api/README.md
@@ -39,6 +39,8 @@ An API to send logging data for persistant storage. Currently the persistant sto
 $ npm install
 ```
 
+`shrinkwrap` is used to lock install module versions to gurentee functional releases. Deleting the `npm-shrinkwrap.json` file before installing with npm will result in the latest versions of packages being installed but the application may not work as expected.
+
 ##### Configuration
 A `./config/mb_config.json` file must have a structure of and contain values for:
 ```

--- a/mb-logging-api/README.md
+++ b/mb-logging-api/README.md
@@ -34,6 +34,32 @@ An API to send logging data for persistant storage. Currently the persistant sto
     * activity_details seralized String
     * activity_date  Date
 
+##### Installation
+```
+$ npm install
+```
+
+##### Configuration
+A `./config/mb_config.json` file must have a structure of and contain values for:
+```
+{
+  "default":
+    {
+      "port": "1234"
+    }
+  ,
+  "mongo":
+    {
+      "development" : "mongodb://localhost/mb-logging",
+      "production" : "mongodb://mongo:27017"
+    }
+}
+
+```
+
+- Copy the sample `./config/SAMPLE_mb_config.json` file.
+
+
 ##### Environment
 ```
 $ export NODE_ENV=<production | development>
@@ -44,7 +70,19 @@ $ export NODE_ENV=<production | development>
 - **`development`**:
   - Use development Mongo database connection settings defined in config/mb_config.json.
 
-##### Start as Deamon
+##### Command Line
 ```
-$ NODE_ENV=<production | development> forever start mb-logging-api-server.js
+$ NODE_ENV=<production | development> ./bin/www
+$ curl -i http://localhost:4733/api
+```
+
+##### Start as Daemon
+```
+$ NODE_ENV=<production | development> forever start ./bin/www
+```
+
+##### Tests
+- to run the unit (supertest / mocha) tests:
+```
+$ npm test
 ```

--- a/mb-logging-api/bin/www
+++ b/mb-logging-api/bin/www
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+var app = require('./../app');
+var mb_config = require(__dirname + './../config/mb_config.json');
+
+/**
+ * Start server.
+ */
+var port = process.env.MB_LOGGING_API_PORT || mb_config.default.port;
+app.listen(port, function() {
+  console.log('Message Broker Logging API server listening on port %d in %s mode.', port, app.settings.env);
+});

--- a/mb-logging-api/bin/www
+++ b/mb-logging-api/bin/www
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var app = require('./../app');
+var app = require('./../mb-logging-api-server');
 var mb_config = require(__dirname + './../config/mb_config.json');
 
 /**

--- a/mb-logging-api/config/SAMPLE_mb_config.json
+++ b/mb-logging-api/config/SAMPLE_mb_config.json
@@ -1,0 +1,13 @@
+{
+  "default":
+    {
+      "port": "1234"
+    }
+  ,
+  "mongo":
+    {
+      "development" : "mongodb://localhost/mb-logging",
+      "production" : "mongodb://mongo:27017"
+    }
+}
+

--- a/mb-logging-api/lib/user-activity.js
+++ b/mb-logging-api/lib/user-activity.js
@@ -2,11 +2,8 @@
  * Interface to the User model.
  */
 
-if (app.get('env') == 'development' || app.get('env') == 'test') {
-  // To output objects for debugging
-  // console.log("/process request: " + util.inspect(request, false, null));
-  var util = require('util');
-}
+// Support output of objects
+var util = require('util');
 
 /**
  * Constructor to the Log object.

--- a/mb-logging-api/lib/user-activity.js
+++ b/mb-logging-api/lib/user-activity.js
@@ -2,7 +2,11 @@
  * Interface to the User model.
  */
 
-var   util = require('util');
+if (app.get('env') == 'development' || app.get('env') == 'test') {
+  // To output objects for debugging
+  // console.log("/process request: " + util.inspect(request, false, null));
+  var util = require('util');
+}
 
 /**
  * Constructor to the Log object.

--- a/mb-logging-api/lib/user-import-summary.js
+++ b/mb-logging-api/lib/user-import-summary.js
@@ -1,7 +1,12 @@
 /**
  * Interface to the User model.
  */
-var util = require('util');
+
+if (app.get('env') == 'development' || app.get('env') == 'test') {
+  // To output objects for debugging
+  // console.log("/process request: " + util.inspect(request, false, null));
+  var util = require('util');
+}
 
 /**
  * Constructor to the UserImportSummary object.

--- a/mb-logging-api/lib/user-import-summary.js
+++ b/mb-logging-api/lib/user-import-summary.js
@@ -63,13 +63,13 @@ UserImportSummary.prototype.post = function(req, res) {
   var logEntry = new this.docModel(addArgs);
   logEntry.save(function(err) {
     if (err) {
-      res.send(500, err);
-      console.log("ERROR - UserImportSummary.prototype.post: " + util.inspect(err, false, null));
+      res.status(500).json(err);
+      console.log("500 Error: POST to  /v1/imports/summaries. err response: " + util.inspect(err, false, null));
+      return;
     }
     // Added log entry to db
-    var fullAddArgs = util.inspect(addArgs, false, null)
-    res.send(201, addArgs);
-    return 1;
+    res.status(201).json("OK");
+
   });
 };
 
@@ -108,14 +108,14 @@ UserImportSummary.prototype.get = function(req, res) {
     ]},
     function (err, docs) {
       if (err) {
-        data.response.send(500, err);
-        return 0;
+        data.response.status(500).json(err);
+        console.log('500 Error: GET to /v1/imports/summaries');
+        return;
       }
 
       // Send results
-      data.response.send(201, docs);
-      console.log('Summary query returned.');
-      return 1;
+      data.response.status(200).json(docs);
+
   }).sort({ target_CSV_file : -1 })
 };
 

--- a/mb-logging-api/lib/user-import-summary.js
+++ b/mb-logging-api/lib/user-import-summary.js
@@ -2,11 +2,9 @@
  * Interface to the User model.
  */
 
-if (app.get('env') == 'development' || app.get('env') == 'test') {
-  // To output objects for debugging
-  // console.log("/process request: " + util.inspect(request, false, null));
-  var util = require('util');
-}
+// Support output of objects
+var util = require('util');
+
 
 /**
  * Constructor to the UserImportSummary object.

--- a/mb-logging-api/lib/user-import.js
+++ b/mb-logging-api/lib/user-import.js
@@ -74,10 +74,12 @@ UserImport.prototype.post = function(req, res) {
   logEntry.save(function(err) {
     if (err) {
       res.send(500, err);
+      console.log("500: Internal Server Error");
+      return;
     }
 
     // Added log entry to db
-    res.send(201, addArgs);
+    res.status(201).json("OK");
   });
 };
 

--- a/mb-logging-api/mb-logging-api-server.js
+++ b/mb-logging-api/mb-logging-api-server.js
@@ -49,10 +49,5 @@ else if (app.get('env') == 'production') {
 // All of routes will be prefixed with /api
 app.use('/api', routes);
 
-/**
- * Start server.
- */
-var port = process.env.MB_LOGGING_API_PORT || mb_config.default.port;
-app.listen(port, function() {
-  console.log('Message Broker Logging API server listening on port %d in %s mode.', port, app.settings.env);
-});
+// Assign to module to allow testing vs binding to a port - via
+module.exports = app;

--- a/mb-logging-api/mb-logging-api-server.js
+++ b/mb-logging-api/mb-logging-api-server.js
@@ -30,7 +30,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
 // Toggle tools and logging based on enviroment setting
-if (app.get('env') == 'development') {
+if (app.get('env') == 'development' || app.get('env') == 'test') {
   // To output objects for debugging
   // console.log("/ request: " + util.inspect(request, false, null));
   var util = require('util');

--- a/mb-logging-api/mb-logging-api-server.js
+++ b/mb-logging-api/mb-logging-api-server.js
@@ -6,7 +6,6 @@ var fs                = require('fs');
 var morgan            = require('morgan');
  
 var routes = require('./routes/routes');
-var mb_config = require(__dirname + '/config/mb_config.json');
 var logDirectory = __dirname + '/logs';
 
 /**

--- a/mb-logging-api/model/model.js
+++ b/mb-logging-api/model/model.js
@@ -5,7 +5,7 @@ module.exports = (function() {
   var mongoose  = require('mongoose');
   var mb_config = require('config/mb_config.json');
   
-  if (app.get('env') == 'development') {
+  if (app.get('env') == 'development' || app.get('env') == 'test') {
     // To output objects for debugging
     // console.log("/process request: " + util.inspect(request, false, null));
     var util = require('util');
@@ -16,8 +16,13 @@ module.exports = (function() {
   // Mongoose (MongoDB)
   // =============================================================================
   // All configurations related to the mb-logging Mongo database.
+  var collectionIndentifier = '';
   if (app.get('env') == 'production') {
     var mongoUri = mb_config.mongo.production;
+  }
+  else if (app.get('env') == 'test') {
+    var mongoUri = mb_config.mongo.test;
+    var collectionIndentifier = '_test';
   }
   else {
     var mongoUri = mb_config.mongo.development;
@@ -29,14 +34,14 @@ module.exports = (function() {
   });
   
   // Define schema / models
-  var userImportCollectionName_Niche = 'userimport-niche';
-  var userImportCollectionName_HerCampus = 'userimport-hercampus';
-  var userImportCollectionName_ATT_iChannel = 'userimport-att-ichannel';
-  var userImportCollectionName_TeenLife = 'userimport-teenlife';
-  
-  var importSummaryCollectionName = 'import-summary';
-  
-  var userActivityCollectionName = 'user-activity';
+  var userImportCollectionName_Niche = 'userimport-niche' + collectionIndentifier;
+  var userImportCollectionName_HerCampus = 'userimport-hercampus' + collectionIndentifier;
+  var userImportCollectionName_ATT_iChannel = 'userimport-att-ichannel' + collectionIndentifier;
+  var userImportCollectionName_TeenLife = 'userimport-teenlife' + collectionIndentifier;
+  var importSummaryCollectionName = 'import-summary' + collectionIndentifier;
+  var userActivityCollectionName = 'user-activity' + collectionIndentifier;
+
+  console.log('userActivityCollectionName: ' + userActivityCollectionName);
   
   // Connection to Mongo event
   mongoose.connection.once('open', function() {

--- a/mb-logging-api/model/model.js
+++ b/mb-logging-api/model/model.js
@@ -128,8 +128,6 @@ module.exports = (function() {
   
     // Log user activity model
     models.userActivityModel = mongoose.model(userActivityCollectionName, userActivityLoggingSchema);
-  
-    console.log("Connection to Mongo (%s) succeeded! Ready to go...\n\n", mongoUri);
   });
 
   return models;

--- a/mb-logging-api/npm-shrinkwrap.json
+++ b/mb-logging-api/npm-shrinkwrap.json
@@ -1,0 +1,369 @@
+{
+  "name": "mb-logging-api",
+  "version": "0.2.1",
+  "dependencies": {
+    "body-parser": {
+      "version": "1.0.2",
+      "from": "body-parser@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.0.2.tgz",
+      "dependencies": {
+        "type-is": {
+          "version": "1.1.0",
+          "from": "type-is@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.1.0.tgz",
+          "dependencies": {
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@>=1.2.11 <1.3.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            }
+          }
+        },
+        "raw-body": {
+          "version": "1.1.7",
+          "from": "raw-body@>=1.1.2 <1.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+          "dependencies": {
+            "bytes": {
+              "version": "1.0.0",
+              "from": "bytes@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0"
+            }
+          }
+        },
+        "qs": {
+          "version": "0.6.6",
+          "from": "qs@>=0.6.6 <0.7.0"
+        }
+      }
+    },
+    "express": {
+      "version": "4.0.0",
+      "from": "express@>=4.0.0 <4.1.0",
+      "dependencies": {
+        "parseurl": {
+          "version": "1.0.1",
+          "from": "parseurl@1.0.1",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
+        },
+        "accepts": {
+          "version": "1.0.0",
+          "from": "accepts@1.0.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.0.tgz",
+          "dependencies": {
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@>=1.2.11 <1.3.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "negotiator": {
+              "version": "0.3.0",
+              "from": "negotiator@>=0.3.0 <0.4.0"
+            }
+          }
+        },
+        "type-is": {
+          "version": "1.0.0",
+          "from": "type-is@1.0.0",
+          "dependencies": {
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@>=1.2.11 <1.3.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            }
+          }
+        },
+        "range-parser": {
+          "version": "1.0.0",
+          "from": "range-parser@1.0.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
+        },
+        "cookie": {
+          "version": "0.1.0",
+          "from": "cookie@0.1.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+        },
+        "buffer-crc32": {
+          "version": "0.2.1",
+          "from": "buffer-crc32@0.2.1",
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+        },
+        "fresh": {
+          "version": "0.2.2",
+          "from": "fresh@0.2.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
+        },
+        "methods": {
+          "version": "0.1.0",
+          "from": "methods@0.1.0",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz"
+        },
+        "send": {
+          "version": "0.2.0",
+          "from": "send@0.2.0",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.2.0.tgz",
+          "dependencies": {
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@>=1.2.9 <1.3.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            }
+          }
+        },
+        "cookie-signature": {
+          "version": "1.0.3",
+          "from": "cookie-signature@1.0.3",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz"
+        },
+        "merge-descriptors": {
+          "version": "0.0.2",
+          "from": "merge-descriptors@0.0.2",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "from": "utils-merge@1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+        },
+        "escape-html": {
+          "version": "1.0.1",
+          "from": "escape-html@1.0.1",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+        },
+        "qs": {
+          "version": "0.6.6",
+          "from": "qs@0.6.6"
+        },
+        "serve-static": {
+          "version": "1.0.1",
+          "from": "serve-static@1.0.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.1.tgz",
+          "dependencies": {
+            "send": {
+              "version": "0.1.4",
+              "from": "send@0.1.4",
+              "dependencies": {
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@>=1.2.9 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "fresh": {
+                  "version": "0.2.0",
+                  "from": "fresh@0.2.0"
+                },
+                "range-parser": {
+                  "version": "0.0.4",
+                  "from": "range-parser@0.0.4"
+                }
+              }
+            }
+          }
+        },
+        "path-to-regexp": {
+          "version": "0.1.2",
+          "from": "path-to-regexp@0.1.2",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz"
+        },
+        "debug": {
+          "version": "0.8.1",
+          "from": "debug@>=0.7.3 <1.0.0"
+        }
+      }
+    },
+    "file-stream-rotator": {
+      "version": "0.0.6",
+      "from": "file-stream-rotator@>=0.0.6 <0.1.0",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.0.6.tgz",
+      "dependencies": {
+        "moment": {
+          "version": "2.3.1",
+          "from": "moment@2.3.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz"
+        }
+      }
+    },
+    "mongoose": {
+      "version": "3.8.37",
+      "from": "mongoose@>=3.8.8 <3.9.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-3.8.37.tgz",
+      "dependencies": {
+        "mongodb": {
+          "version": "1.4.38",
+          "from": "mongodb@1.4.38",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.38.tgz",
+          "dependencies": {
+            "bson": {
+              "version": "0.2.22",
+              "from": "bson@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.22.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "1.8.4",
+                  "from": "nan@>=1.8.0 <1.9.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                }
+              }
+            },
+            "kerberos": {
+              "version": "0.0.11",
+              "from": "kerberos@0.0.11",
+              "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.11.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "1.8.4",
+                  "from": "nan@>=1.8.0 <1.9.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.0.4",
+              "from": "readable-stream@latest",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6",
+                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "hooks": {
+          "version": "0.2.1",
+          "from": "hooks@0.2.1",
+          "resolved": "https://registry.npmjs.org/hooks/-/hooks-0.2.1.tgz"
+        },
+        "ms": {
+          "version": "0.1.0",
+          "from": "ms@0.1.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.1.0.tgz"
+        },
+        "sliced": {
+          "version": "0.0.5",
+          "from": "sliced@0.0.5",
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
+        },
+        "muri": {
+          "version": "1.1.0",
+          "from": "muri@1.1.0",
+          "resolved": "https://registry.npmjs.org/muri/-/muri-1.1.0.tgz"
+        },
+        "mpromise": {
+          "version": "0.4.3",
+          "from": "mpromise@0.4.3",
+          "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.4.3.tgz"
+        },
+        "mpath": {
+          "version": "0.1.1",
+          "from": "mpath@0.1.1",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz"
+        },
+        "regexp-clone": {
+          "version": "0.0.1",
+          "from": "regexp-clone@0.0.1",
+          "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
+        },
+        "mquery": {
+          "version": "1.6.1",
+          "from": "mquery@1.6.1",
+          "resolved": "https://registry.npmjs.org/mquery/-/mquery-1.6.1.tgz",
+          "dependencies": {
+            "bluebird": {
+              "version": "2.9.26",
+              "from": "bluebird@2.9.26",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "morgan": {
+      "version": "1.6.1",
+      "from": "morgan@>=1.6.0 <1.7.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
+      "dependencies": {
+        "basic-auth": {
+          "version": "1.0.3",
+          "from": "basic-auth@>=1.0.3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "depd": {
+          "version": "1.0.1",
+          "from": "depd@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "from": "on-finished@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.1",
+              "from": "ee-first@1.1.1",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+            }
+          }
+        },
+        "on-headers": {
+          "version": "1.0.1",
+          "from": "on-headers@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+        }
+      }
+    }
+  }
+}

--- a/mb-logging-api/package.json
+++ b/mb-logging-api/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "postinstall" : "node -e \"var modelpath='../model'; var dstmodelpath='node_modules/model'; var srcpath='../lib'; var dstsrcpath='node_modules/lib'; var cfgpath='../config'; var dstcfgpath='node_modules/config'; var fs=require('fs'); fs.exists(dstmodelpath,function(modelexists){if(!modelexists){fs.symlinkSync(modelpath, dstmodelpath,'dir');}});fs.exists(dstsrcpath,function(srcexists){if(!srcexists){fs.symlinkSync(srcpath, dstsrcpath,'dir');}});fs.exists(dstcfgpath,function(cfgexists){if(!cfgexists){fs.symlinkSync(cfgpath, dstcfgpath,'dir');}});\",",
-    "test": "mocha test.js"
+    "test": "NODE_ENV=development mocha mb-logging-api-server.js test.js"
   },
   "license": "MIT"
 }

--- a/mb-logging-api/package.json
+++ b/mb-logging-api/package.json
@@ -36,10 +36,11 @@
   },
   "devDependencies": {
     "supertest": "^1.1.0",
+    "should": "^8.0.1",
     "mocha":"^2.3.4"
   },
   "scripts": {
-    "postinstall" : "node -e \"var modelpath='../model'; var dstmodelpath='node_modules/model'; var srcpath='../lib'; var dstsrcpath='node_modules/lib'; var cfgpath='../config'; var dstcfgpath='node_modules/config'; var fs=require('fs'); fs.exists(dstmodelpath,function(modelexists){if(!modelexists){fs.symlinkSync(modelpath, dstmodelpath,'dir');}});fs.exists(dstsrcpath,function(srcexists){if(!srcexists){fs.symlinkSync(srcpath, dstsrcpath,'dir');}});fs.exists(dstcfgpath,function(cfgexists){if(!cfgexists){fs.symlinkSync(cfgpath, dstcfgpath,'dir');}});\",",
+    "postinstall" : "node -e \"var modelpath='../model'; var dstmodelpath='node_modules/model'; var srcpath='../lib'; var dstsrcpath='node_modules/lib'; var cfgpath='../config'; var dstcfgpath='node_modules/config'; var fs=require('fs'); fs.exists(dstmodelpath,function(modelexists){if(!modelexists){fs.symlinkSync(modelpath, dstmodelpath,'dir');}});fs.exists(dstsrcpath,function(srcexists){if(!srcexists){fs.symlinkSync(srcpath, dstsrcpath,'dir');}});fs.exists(dstcfgpath,function(cfgexists){if(!cfgexists){fs.symlinkSync(cfgpath, dstcfgpath,'dir');}});\"",
     "test": "NODE_ENV=development mocha mb-logging-api-server.js test.js"
   },
   "license": "MIT"

--- a/mb-logging-api/package.json
+++ b/mb-logging-api/package.json
@@ -35,7 +35,8 @@
     "file-stream-rotator": "~0.0.6"
   },
   "devDependencies": {
-    "supertest": "^1.1.0"
+    "supertest": "^1.1.0",
+    "mocha":"^2.3.4"
   },
   "scripts": {
     "postinstall" : "node -e \"var modelpath='../model'; var dstmodelpath='node_modules/model'; var srcpath='../lib'; var dstsrcpath='node_modules/lib'; var cfgpath='../config'; var dstcfgpath='node_modules/config'; var fs=require('fs'); fs.exists(dstmodelpath,function(modelexists){if(!modelexists){fs.symlinkSync(modelpath, dstmodelpath,'dir');}});fs.exists(dstsrcpath,function(srcexists){if(!srcexists){fs.symlinkSync(srcpath, dstsrcpath,'dir');}});fs.exists(dstcfgpath,function(cfgexists){if(!cfgexists){fs.symlinkSync(cfgpath, dstcfgpath,'dir');}});\""

--- a/mb-logging-api/package.json
+++ b/mb-logging-api/package.json
@@ -39,7 +39,8 @@
     "mocha":"^2.3.4"
   },
   "scripts": {
-    "postinstall" : "node -e \"var modelpath='../model'; var dstmodelpath='node_modules/model'; var srcpath='../lib'; var dstsrcpath='node_modules/lib'; var cfgpath='../config'; var dstcfgpath='node_modules/config'; var fs=require('fs'); fs.exists(dstmodelpath,function(modelexists){if(!modelexists){fs.symlinkSync(modelpath, dstmodelpath,'dir');}});fs.exists(dstsrcpath,function(srcexists){if(!srcexists){fs.symlinkSync(srcpath, dstsrcpath,'dir');}});fs.exists(dstcfgpath,function(cfgexists){if(!cfgexists){fs.symlinkSync(cfgpath, dstcfgpath,'dir');}});\""
+    "postinstall" : "node -e \"var modelpath='../model'; var dstmodelpath='node_modules/model'; var srcpath='../lib'; var dstsrcpath='node_modules/lib'; var cfgpath='../config'; var dstcfgpath='node_modules/config'; var fs=require('fs'); fs.exists(dstmodelpath,function(modelexists){if(!modelexists){fs.symlinkSync(modelpath, dstmodelpath,'dir');}});fs.exists(dstsrcpath,function(srcexists){if(!srcexists){fs.symlinkSync(srcpath, dstsrcpath,'dir');}});fs.exists(dstcfgpath,function(cfgexists){if(!cfgexists){fs.symlinkSync(cfgpath, dstcfgpath,'dir');}});\",",
+    "test": "mocha test.js"
   },
   "license": "MIT"
 }

--- a/mb-logging-api/package.json
+++ b/mb-logging-api/package.json
@@ -34,6 +34,9 @@
     "morgan": "~1.6.0",
     "file-stream-rotator": "~0.0.6"
   },
+  "devDependencies": {
+    "supertest": "^1.1.0"
+  },
   "scripts": {
     "postinstall" : "node -e \"var modelpath='../model'; var dstmodelpath='node_modules/model'; var srcpath='../lib'; var dstsrcpath='node_modules/lib'; var cfgpath='../config'; var dstcfgpath='node_modules/config'; var fs=require('fs'); fs.exists(dstmodelpath,function(modelexists){if(!modelexists){fs.symlinkSync(modelpath, dstmodelpath,'dir');}});fs.exists(dstsrcpath,function(srcexists){if(!srcexists){fs.symlinkSync(srcpath, dstsrcpath,'dir');}});fs.exists(dstcfgpath,function(cfgexists){if(!cfgexists){fs.symlinkSync(cfgpath, dstcfgpath,'dir');}});\""
   },

--- a/mb-logging-api/routes/routes.js
+++ b/mb-logging-api/routes/routes.js
@@ -56,7 +56,7 @@ module.exports = (function() {
            req.body.phone === undefined &&
            req.body.drupal_uid === undefined)
       ) {
-      res.send(400, 'Type, exists and source, origin or started_timestamp not specified or no email, phone or Drupal uid specified.');
+      res.status(400).json('Type, exists and source, origin or started_timestamp not specified or no email, phone or Drupal uid specified.');
     }
     else {
   
@@ -98,7 +98,7 @@ module.exports = (function() {
         req.body.target_CSV_file === undefined ||
         req.body.signup_count === undefined ||
         req.body.skipped === undefined) {
-      res.send(400, 'POST /api/v1/imports/summaries request. Type or source not specified or no target CSV file, signup count and skipped values specified.');
+      res.status(400).json('POST /api/v1/imports/summaries request. Type or source not specified or no target CSV file, signup count and skipped values specified.');
     }
     else {
       var userImportSummary = new UserImportSummary(model.importSummaryModel);

--- a/mb-logging-api/routes/routes.js
+++ b/mb-logging-api/routes/routes.js
@@ -26,10 +26,10 @@ module.exports = (function() {
    * GET /api/v1
    */
   router.get('/', function(req, res) {
-    res.send(200, 'Message Broker Logging API (mb-logging-api). Available versions: v1 (/api/v1) See https://github.com/DoSomething/MessageBroker-Node/tree/master/mb-logging-api for the related git repository.');
+    res.status(200).json('Message Broker Logging API (mb-logging-api). Available versions: v1 (/api/v1) See https://github.com/DoSomething/MessageBroker-Node/tree/master/mb-logging-api for the related git repository.');
   });
   router.get('/v1', function(req, res) {
-    res.send(200, 'Message Broker Logging API (mb-logging-api). Version 1.x.x, see wiki (https://github.com/DoSomething/MessageBroker-Node/wiki/mb-logging-api) for documentation');
+    res.status(200).json('Message Broker Logging API (mb-logging-api). Version 1.x.x, see wiki (https://github.com/DoSomething/MessageBroker-Node/wiki/mb-logging-api) for documentation');
   });
 
   /**

--- a/mb-logging-api/routes/routes.js
+++ b/mb-logging-api/routes/routes.js
@@ -131,7 +131,7 @@ module.exports = (function() {
   
     .post(function(req, res) {
       if (req.query.type != 'vote') {
-        res.send(400, 'POST /api/v1/user/activity request. Type not supported activity: ' + req.body.type);
+        res.status(400).json('POST /api/v1/user/activity request. Type not supported activity: ' + req.body.type);
       }
       else {
         var userActivity = new UserActivity(model.userActivityModel);
@@ -141,7 +141,7 @@ module.exports = (function() {
   
     .get(function(req, res) {
       if (req.query.type === undefined && req.query.source === undefined) {
-        res.send(400, 'GET /api/v1/user/activity request, type and/or source not defined. ');
+        res.status(400).json('GET /api/v1/user/activity request, type and/or source not defined. ');
       }
       else {
         var userActivity = new UserActivity(model.userActivityModel);

--- a/mb-logging-api/routes/routes.js
+++ b/mb-logging-api/routes/routes.js
@@ -15,7 +15,7 @@ module.exports = (function() {
   var UserImportSummary = require('lib/user-import-summary');
   var UserActivity = require('lib/user-activity');
 
-  if (app.get('env') == 'development') {
+  if (app.get('env') == 'development' || app.get('env') == 'test') {
     // To output objects for debugging
     // console.log("/process request: " + util.inspect(request, false, null));
     var util = require('util');
@@ -56,7 +56,7 @@ module.exports = (function() {
            req.body.phone === undefined &&
            req.body.drupal_uid === undefined)
       ) {
-      res.status(400).json('Type, exists and source, origin or started_timestamp not specified or no email, phone or Drupal uid specified.');
+      res.status(400).json('type, exists, source and origin or processed_timestamp not specified or no email, phone or drupal_uid specified.');
     }
     else {
   

--- a/mb-logging-api/routes/routes.js
+++ b/mb-logging-api/routes/routes.js
@@ -26,10 +26,10 @@ module.exports = (function() {
    * GET /api/v1
    */
   router.get('/', function(req, res) {
-    res.send(200, 'Message Broker Logging API (mb-logging-api). Available versions: v1 (/api/v1) See https://github.com/DoSomething/mb-logging-api for the related git repository.');
+    res.send(200, 'Message Broker Logging API (mb-logging-api). Available versions: v1 (/api/v1) See https://github.com/DoSomething/MessageBroker-Node/tree/master/mb-logging-api for the related git repository.');
   });
   router.get('/v1', function(req, res) {
-    res.send(200, 'Message Broker Logging API (mb-logging-api). Version 1.x.x, see wiki (https://github.com/DoSomething/mb-logging-api/wiki) for documentation');
+    res.send(200, 'Message Broker Logging API (mb-logging-api). Version 1.x.x, see wiki (https://github.com/DoSomething/MessageBroker-Node/wiki/mb-logging-api) for documentation');
   });
 
   /**

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -32,3 +32,19 @@ describe('Requests to v1 root (/api/v1) path', function() {
   });
 
 });
+
+describe('Requests to v1 imports (/api/v1/imports) path', function() {
+
+  it('Returns a 400 status code when required parameters type, exists, source, origin, processed_timestamp and email or phone or drupal_uid are not defined.', function(done) {
+
+    request(app)
+      .post('/api/v1/imports')
+      .expect(400)
+      .end(function(error) {
+        if (error) throw error;
+        done();
+      });
+
+  });
+
+});

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -1,10 +1,17 @@
 var request = require('supertest');
 var app = require('./mb-logging-api-server');
 
-request(app)
-  .get('/')
-  .expect(200)
-  .end(function(error) {
-    if (error) throw error;
-    console.log('Done');
-  });
+describe('Requests to the root (/api) path', function() {
+
+  it('Returns a 200 status code', function(done) {
+
+    request(app)
+      .get('/api')
+      .expect(200)
+      .end(function(error) {
+        if (error) throw error;
+        done();
+      });
+    });
+
+});

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -10,6 +10,13 @@ describe('Requests to the root (/api) path', function() {
       .expect(200, done);
   });
 
+  it('GET: Returns JSON format', function(done) {
+
+    request(app)
+      .get('/api/v1')
+      .expect('content-type', 'application/json', done);
+  });
+
 });
 
 describe('Requests to v1 root (/api/v1) path', function() {
@@ -19,6 +26,13 @@ describe('Requests to v1 root (/api/v1) path', function() {
     request(app)
       .get('/api/v1')
       .expect(200, done);
+  });
+
+  it('GET: Returns JSON format', function(done) {
+
+    request(app)
+      .get('/api/v1')
+      .expect('content-type', 'application/json', done);
   });
 
 });

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -13,7 +13,7 @@ describe('Requests to the root (/api) path', function() {
   it('GET: Returns JSON format', function(done) {
 
     request(app)
-      .get('/api/v1')
+      .get('/api')
       .expect('content-type', 'application/json', done);
   });
 
@@ -39,40 +39,68 @@ describe('Requests to v1 root (/api/v1) path', function() {
 
 describe('Requests to v1 imports (/api/v1/imports) path', function() {
 
-  it('POST: Returns a 400 status code when required parameters type, exists, source, origin, processed_timestamp and email or phone or drupal_uid are not defined.', function(done) {
+  it('POST: Returns a 400 status code when required parameters "type", "exists", "source", "origin", "processed_timestamp" and "email" OR "phone" or "drupal_uid" are not defined.', function(done) {
 
     request(app)
       .post('/api/v1/imports')
       .expect(400, done);
   });
 
+  it('POST: Returns JSON format', function(done) {
+
+    request(app)
+      .post('/api/v1/imports')
+      .expect('content-type', 'application/json', done);
+  });
+
 });
 
 describe('Requests to v1 imports (/api/v1/imports/summaries) path', function() {
 
-  it('POST: Returns a 400 status code when required parameters type,source, target_CSV_file, signup_count and skipped are not defined.', function(done) {
+  it('POST: Returns a 400 status code when required parameters "type", "source", "target_CSV_file", "signup_count" and "skipped" are not defined.', function(done) {
 
     request(app)
       .post('/api/v1/imports/summaries')
       .expect(400, done);
   });
 
+  it('POST: Returns JSON format', function(done) {
+
+    request(app)
+      .post('/api/v1/imports/summaries')
+      .expect('content-type', 'application/json', done);
+  });
+
 });
 
 describe('Requests to v1 imports (/api/v1/user/activity) path', function() {
 
-  it('POST: Returns a 400 status code when required parameter vote is not defined.', function(done) {
+  it('POST: Returns a 400 status code when required parameter "vote" is not defined.', function(done) {
 
     request(app)
       .post('/api/v1/user/activity')
       .expect(400, done);
   });
 
-it('GET: Returns a 400 status code when required parameter "type" and "source" are not defined.', function(done) {
+  it('POST: Returns JSON format', function(done) {
+
+    request(app)
+      .post('/api/v1/user/activity')
+      .expect('content-type', 'application/json', done);
+  });
+
+  it('GET: Returns a 400 status code when required parameter "type" and "source" are not defined.', function(done) {
 
     request(app)
       .get('/api/v1/user/activity')
       .expect(400, done);
+  });
+
+  it('GET: Returns JSON format', function(done) {
+
+    request(app)
+      .get('/api/v1/user/activity')
+      .expect('content-type', 'application/json', done);
   });
 
 });

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -3,7 +3,7 @@ var app = require('./mb-logging-api-server');
 
 describe('Requests to the root (/api) path', function() {
 
-  it('Returns a 200 status code', function(done) {
+  it('GET: Returns a 200 status code', function(done) {
 
     request(app)
       .get('/api')
@@ -19,7 +19,7 @@ describe('Requests to the root (/api) path', function() {
 
 describe('Requests to v1 root (/api/v1) path', function() {
 
-  it('Returns a 200 status code', function(done) {
+  it('GET: Returns a 200 status code', function(done) {
 
     request(app)
       .get('/api/v1')
@@ -35,7 +35,7 @@ describe('Requests to v1 root (/api/v1) path', function() {
 
 describe('Requests to v1 imports (/api/v1/imports) path', function() {
 
-  it('Returns a 400 status code when required parameters type, exists, source, origin, processed_timestamp and email or phone or drupal_uid are not defined.', function(done) {
+  it('POST: Returns a 400 status code when required parameters type, exists, source, origin, processed_timestamp and email or phone or drupal_uid are not defined.', function(done) {
 
     request(app)
       .post('/api/v1/imports')
@@ -51,7 +51,7 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
 
 describe('Requests to v1 imports (/api/v1/imports/summaries) path', function() {
 
-  it('Returns a 400 status code when required parameters type,source, target_CSV_file, signup_count and skipped are not defined.', function(done) {
+  it('POST: Returns a 400 status code when required parameters type,source, target_CSV_file, signup_count and skipped are not defined.', function(done) {
 
     request(app)
       .post('/api/v1/imports/summaries')

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -1,5 +1,5 @@
 var request = require('supertest');
-var app = require('./app');
+var app = require('./mb-logging-api-server');
 
 request(app)
   .get('/')

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -48,3 +48,35 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
   });
 
 });
+
+describe('Requests to v1 imports (/api/v1/imports/summaries) path', function() {
+
+  it('Returns a 400 status code when required parameters type,source, target_CSV_file, signup_count and skipped are not defined.', function(done) {
+
+    request(app)
+      .post('/api/v1/imports/summaries')
+      .expect(400)
+      .end(function(error) {
+        if (error) throw error;
+        done();
+      });
+
+  });
+
+});
+
+describe('Requests to v1 imports (/api/v1/user/activity) path', function() {
+
+  it('Returns a 400 status code when required parameter vote is not defined.', function(done) {
+
+    request(app)
+      .post('/api/v1/user/activity')
+      .expect(400)
+      .end(function(error) {
+        if (error) throw error;
+        done();
+      });
+
+  });
+
+});

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -67,10 +67,22 @@ describe('Requests to v1 imports (/api/v1/imports/summaries) path', function() {
 
 describe('Requests to v1 imports (/api/v1/user/activity) path', function() {
 
-  it('Returns a 400 status code when required parameter vote is not defined.', function(done) {
+  it('POST: Returns a 400 status code when required parameter vote is not defined.', function(done) {
 
     request(app)
       .post('/api/v1/user/activity')
+      .expect(400)
+      .end(function(error) {
+        if (error) throw error;
+        done();
+      });
+
+  });
+
+it('GET: Returns a 400 status code when required parameter "type" and "source" are not defined.', function(done) {
+
+    request(app)
+      .get('/api/v1/user/activity')
       .expect(400)
       .end(function(error) {
         if (error) throw error;

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -1,0 +1,10 @@
+var request = require('supertest');
+var app = require('./app');
+
+request(app)
+  .get('/')
+  .expect(200)
+  .end(function(error) {
+    if (error) throw error;
+    console.log('Done');
+  });

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -58,7 +58,7 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
       .expect(400, done);
   });
 
-  it('POST: Returns JSON format', function(done) {
+  it('POST: Returns JSON format with 400 response.', function(done) {
 
     request(app)
       .post('/api/v1/imports')
@@ -70,7 +70,7 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
 
   });
 
-  it('POST: Addition of import log entry returns 201 response code.', function(done) {
+  it('POST: Addition of import log entry returns 201 response code and "OK" message.', function(done) {
 
     urlParams = '?source=niche&exists=1&origin=Niche-12-12-15.csv&processed_timestamp=1000000000&type=user_import';
     request(app)
@@ -123,11 +123,54 @@ describe('Requests to v1 imports (/api/v1/imports/summaries) path', function() {
       .expect(400, done);
   });
 
-  it('POST: Returns JSON format', function(done) {
+  it('POST: Returns JSON format with 400 response.', function(done) {
 
     request(app)
       .post('/api/v1/imports/summaries')
       .expect('content-type', 'application/json', done);
+  });
+
+  // @todo
+  it('GET: Lookup of missing import summary log entries returns 404 response code.', function(done) {
+
+  });
+
+  it('POST: Addition of import log summary entry returns 201 response code and "OK" message.', function(done) {
+
+    urlParams = '?source=niche&type=user_import';
+    request(app)
+      .post('/api/v1/imports/summaries' + urlParams)
+      .send({
+        "logging_timestamp": "1410000000",
+        "target_CSV_file": "2015-13-00.csv",
+        "signup_count": "69",
+        "skipped": "1"
+      })
+      .expect("content-type", /json/)
+      .expect(201)
+      .end(function(err, response) {
+        if (err) {
+          throw err;
+        }
+        response.status.should.equal(201)
+        response.body.should.equal("OK")
+        done();
+      });
+  });
+
+  // @todo
+  it('GET: Lookup of summary import log entry returns 200 response code. Returned data is formatted as expected.', function(done) {
+
+  });
+
+  // @todo
+  it('DELETE: Test summary log entry returns 200 response code.', function(done) {
+
+  });
+
+  // @todo
+  it('GET: Lookup of deleted import summary log entry returns 404 response code.', function(done) {
+
   });
 
 });

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -12,6 +12,23 @@ describe('Requests to the root (/api) path', function() {
         if (error) throw error;
         done();
       });
-    });
+
+  });
+
+});
+
+describe('Requests to v1 root (/api/v1) path', function() {
+
+  it('Returns a 200 status code', function(done) {
+
+    request(app)
+      .get('/api/v1')
+      .expect(200)
+      .end(function(error) {
+        if (error) throw error;
+        done();
+      });
+
+  });
 
 });

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -10,6 +10,7 @@
  */
 
 var request = require('supertest');
+var should = require('should');
 var app = require('./mb-logging-api-server');
 
 describe('Requests to the root (/api) path', function() {
@@ -64,49 +65,51 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
       .expect('content-type', 'application/json', done);
   });
 
-  /**
-   * Future test: POST to /api/v1/imports with the following parameters
-   * source=teenlife&exists=1&origin=TeenLife-12-12-15.csv&processed_timestamp=1425767744&type=user_import
-   *
-   * and the following body:
-   * var importEvent = {
-   *   "logging_timestamp": "1410285144",
-   *   "phone": "2345678901",
-   *   "phone_status": "Still a phone number",
-   *   "email": "test4@test.com",
-   *   "email_status": "We got this one too.",
-   *    "email_acquired_timestamp": "1310285144",
-   *    "drupal_uid": "23456789",
-   *    "drupal_email": "test4@test.com"
-   * };
-   *
-   * request(app)
-   *   .post('/api/v1/imports')
-   *   .send(importEvent)
-   *
-   * NOTE: Consider using "should" library. Note Express 3 example:
-   *   .end(function(err, res) {
-   *     if (err) {
-   *       throw err;
-   *     }
-   *     // this is should.js syntax, very clear
-   *    res.should.have.status(400);
-   *      done();
-   *     });
-   */
+  // @todo
+  it('GET: Lookup of missing import log entry returns 404 response code.', function(done) {
+
+  });
 
   it('POST: Addition of import log entry returns 201 response code.', function(done) {
 
+    urlParams = '?source=niche&exists=1&origin=Niche-12-12-15.csv&processed_timestamp=1000000000&type=user_import';
     request(app)
-      .post('/api/v1/imports')
-      .expect(201, done);
+      .post('/api/v1/imports' + urlParams)
+      .send({
+        "logging_timestamp": "1410000000",
+        "phone": "1234567890",
+        "phone_status": "Still a phone number",
+        "email": "test@test.com",
+        "email_status": "We got this one too.",
+        "email_acquired_timestamp": "1400000000",
+        "drupal_uid": "12000000",
+        "drupal_email": "test@test.com"
+      })
+      .expect("content-type", /json/)
+      .expect(201)
+      .end(function(err, response) {
+        if (err) {
+          throw err;
+        }
+        response.status.should.equal(201)
+        response.body.should.equal("OK")
+        done();
+      });
   });
 
-  it('POST: Returns JSON format', function(done) {
+  // @todo
+  it('GET: Lookup of import log entry returns 200 response code. Returned data is formatted as expected.', function(done) {
 
-    request(app)
-      .post('/api/v1/imports')
-      .expect('content-type', 'application/json', done);
+  });
+
+  // @todo
+  it('DELETE: Test import log entry returns 200 response code.', function(done) {
+
+  });
+
+  // @todo
+  it('GET: Lookup of deleted import log entry returns 404 response code.', function(done) {
+
   });
 
 });

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -7,12 +7,7 @@ describe('Requests to the root (/api) path', function() {
 
     request(app)
       .get('/api')
-      .expect(200)
-      .end(function(error) {
-        if (error) throw error;
-        done();
-      });
-
+      .expect(200, done);
   });
 
 });
@@ -23,12 +18,7 @@ describe('Requests to v1 root (/api/v1) path', function() {
 
     request(app)
       .get('/api/v1')
-      .expect(200)
-      .end(function(error) {
-        if (error) throw error;
-        done();
-      });
-
+      .expect(200, done);
   });
 
 });
@@ -39,12 +29,7 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
 
     request(app)
       .post('/api/v1/imports')
-      .expect(400)
-      .end(function(error) {
-        if (error) throw error;
-        done();
-      });
-
+      .expect(400, done);
   });
 
 });
@@ -55,12 +40,7 @@ describe('Requests to v1 imports (/api/v1/imports/summaries) path', function() {
 
     request(app)
       .post('/api/v1/imports/summaries')
-      .expect(400)
-      .end(function(error) {
-        if (error) throw error;
-        done();
-      });
-
+      .expect(400, done);
   });
 
 });
@@ -71,24 +51,14 @@ describe('Requests to v1 imports (/api/v1/user/activity) path', function() {
 
     request(app)
       .post('/api/v1/user/activity')
-      .expect(400)
-      .end(function(error) {
-        if (error) throw error;
-        done();
-      });
-
+      .expect(400, done);
   });
 
 it('GET: Returns a 400 status code when required parameter "type" and "source" are not defined.', function(done) {
 
     request(app)
       .get('/api/v1/user/activity')
-      .expect(400)
-      .end(function(error) {
-        if (error) throw error;
-        done();
-      });
-
+      .expect(400, done);
   });
 
 });

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -1,3 +1,14 @@
+/**
+ * Test for mb-logging-api
+ *
+ * References:
+ *   - HOW TO BUILD AND TEST YOUR REST API WITH NODE.JS, EXPRESS AND MOCHA
+ *     https://thewayofcode.wordpress.com/tag/supertest
+ *
+ *   - Shpuld Library
+ *     https://www.npmjs.com/package/should
+ */
+
 var request = require('supertest');
 var app = require('./mb-logging-api-server');
 
@@ -44,6 +55,51 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
     request(app)
       .post('/api/v1/imports')
       .expect(400, done);
+  });
+
+  it('POST: Returns JSON format', function(done) {
+
+    request(app)
+      .post('/api/v1/imports')
+      .expect('content-type', 'application/json', done);
+  });
+
+  /**
+   * Future test: POST to /api/v1/imports with the following parameters
+   * source=teenlife&exists=1&origin=TeenLife-12-12-15.csv&processed_timestamp=1425767744&type=user_import
+   *
+   * and the following body:
+   * var importEvent = {
+   *   "logging_timestamp": "1410285144",
+   *   "phone": "2345678901",
+   *   "phone_status": "Still a phone number",
+   *   "email": "test4@test.com",
+   *   "email_status": "We got this one too.",
+   *    "email_acquired_timestamp": "1310285144",
+   *    "drupal_uid": "23456789",
+   *    "drupal_email": "test4@test.com"
+   * };
+   *
+   * request(app)
+   *   .post('/api/v1/imports')
+   *   .send(importEvent)
+   *
+   * NOTE: Consider using "should" library. Note Express 3 example:
+   *   .end(function(err, res) {
+   *     if (err) {
+   *       throw err;
+   *     }
+   *     // this is should.js syntax, very clear
+   *    res.should.have.status(400);
+   *      done();
+   *     });
+   */
+
+  it('POST: Addition of import log entry returns 201 response code.', function(done) {
+
+    request(app)
+      .post('/api/v1/imports')
+      .expect(201, done);
   });
 
   it('POST: Returns JSON format', function(done) {


### PR DESCRIPTION
Fixes #5 

Add test coverage to `mb-logging-api` based on Code School Soup to Bits: Building Blocks of Express: https://www.codeschool.com/screencasts/soup-to-bits-building-blocks-of-express-js#comments

Use:
- Super Test: https://www.npmjs.com/package/supertest - "Super-agent driven library for testing HTTP servers"
- `/bin/www` convention to load app as module to run tests or bind to a port for production.
