### PR TITLE
Tests Coverage for /api/v1/imports/summaries

### DIFF
--- a/mb-logging-api/lib/user-import-summary.js
+++ b/mb-logging-api/lib/user-import-summary.js
@@ -121,4 +121,46 @@ UserImportSummary.prototype.get = function(req, res) {
   }).sort({ target_CSV_file : -1 })
 };
 
+/**
+ * Delete existing user import summary log documents.
+ *
+ * @param req
+ *   The request object in the DELETE callback.
+ * @param res
+ *   The response object in the DELETE callback.
+ */
+UserImportSummary.prototype.delete = function(req, res) {
+
+  this.request = req;
+  this.response = res;
+  var deleteArgs = {};
+  var targetSource = this.request.query.source;
+  deleteArgs.source = targetSource;
+
+  if (this.request.query.origin !== undefined) {
+    var targetOrigin = this.request.query.origin;
+    deleteArgs.target_CSV_file = targetOrigin;
+  }
+
+  this.docModel.remove(deleteArgs,
+    function(err, num) {
+
+      if (err) {
+        console.log('ERROR delete: ' + err);
+        res.status(500).json(err);
+        return;
+      }
+
+      if (num == 0) {
+        var message = 'OK - No documents found to delete for target_CSV_file: ' + targetOrigin;
+        res.status(404).json(message);
+      }
+      else {
+        var message = 'OK - Deleted ' + num + ' document(s) for origin: ' + targetOrigin;
+        res.status(200).json(message);
+      }
+    }
+  );
+};
+
 module.exports = UserImportSummary;

--- a/mb-logging-api/lib/user-import-summary.js
+++ b/mb-logging-api/lib/user-import-summary.js
@@ -69,7 +69,6 @@ UserImportSummary.prototype.post = function(req, res) {
     }
     // Added log entry to db
     res.status(201).json("OK");
-
   });
 };
 
@@ -84,17 +83,17 @@ UserImportSummary.prototype.post = function(req, res) {
  */
 UserImportSummary.prototype.get = function(req, res) {
 
-  if (req.param("start_date") == 0) {
+  if (req.params.start_processed_date === undefined) {
     var targetStartDate = new Date('2014-08-01');
   }
   else {
-    var targetStartDate = new Date(req.param("start_date"));
+    var targetStartDate = new Date(req.params.start_processed_date);
   }
-  if (req.param("end_date") == 0) {
+  if (req.params.end_processed_date === undefined) {
     var targetEndDate = new Date();
   }
   else {
-    var targetEndDate = new Date(req.param("end_date"));
+    var targetEndDate = new Date(req.params.start_processed_date);
   }
 
   var data = {
@@ -108,13 +107,16 @@ UserImportSummary.prototype.get = function(req, res) {
     ]},
     function (err, docs) {
       if (err) {
-        data.response.status(500).json(err);
-        console.log('500 Error: GET to /v1/imports/summaries');
+        data.response.send(500, err);
         return;
       }
 
-      // Send results
-      data.response.status(200).json(docs);
+      if (docs.length == 0) {
+        res.status(404).json('OK - No match found for source ' + req.query.source + ' logged_date: gte: ' + targetStartDate + ' lte ' + targetEndDate);
+      }
+      else {
+        res.status(200).json(docs);
+      }
 
   }).sort({ target_CSV_file : -1 })
 };

--- a/mb-logging-api/routes/routes.js
+++ b/mb-logging-api/routes/routes.js
@@ -153,6 +153,8 @@ module.exports = (function() {
     });
 
     /**
+     * @todo:
+     *
      * GET
      * router.route('/v1/imports:start_processed_date')
      * router.route('/v1/imports:start_processed_date/:end_processed_date')
@@ -173,20 +175,52 @@ module.exports = (function() {
    * @param source string
    *   &source=niche.com : Unique name to identify the source of the import data.
    */
-  router.post('/v1/imports/summaries', function(req, res) {
-    if (req.query.type === undefined ||
+  router.route('/v1/imports/summaries')
+
+    .post(function(req, res) {
+      if (req.query.type === undefined ||
         req.query.source === undefined ||
         req.body.target_CSV_file === undefined ||
         req.body.signup_count === undefined ||
         req.body.skipped === undefined) {
-      res.status(400).json('POST /api/v1/imports/summaries request. Type or source not specified or no target CSV file, signup count and skipped values specified.');
+        res.status(400).json('ERROR, missing required value. POST /api/v1/imports/summaries request. Type or source not specified or no target CSV file, signup count and skipped values specified.');
+      }
+      else {
+        var userImportSummary = new UserImportSummary(model.importSummaryModel);
+        userImportSummary.post(req, res);
+      }
+    })
+
+    /**
+     * GET ?type=user_import&source=teenlife&origin=TeenLife-12-12-15.csv
+     */
+    .get(function(req, res) {
+      if (req.query.type === undefined ||
+          req.query.source === undefined) {
+        res.status(400).json('type or source not specified.');
+      }
+      else {
+        var userImportSummary = new UserImportSummary(model.importSummaryModel);
+        userImportSummary.get(req, res);
+      }
+
+    })
+
+    .delete(function(req, res) {
+
+      if (req.query.type === undefined ||
+          req.query.source === undefined ||
+          req.query.origin === undefined) {
+        res.status(400).json('type, source and origin not specified.');
+      }
+      else {
+        var userImportSummary = new UserImportSummary(model.importSummaryModel);
+        userImportSummary.delete(req, res);
+      }
+
     }
-    else {
-      var userImportSummary = new UserImportSummary(model.importSummaryModel);
-      userImportSummary.post(req, res);
-    }
-  });
-  
+  );
+
   /**
    * POST to /v1/user/activity
    *   Required parameter:

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -246,13 +246,49 @@ describe('Requests to v1 imports (/api/v1/imports/summaries) path', function() {
 
   it('DELETE: Import summary log entry returns 200 response code and expected OK response.', function(done) {
 
+    urlParams = '?type=user_import&source=teenlife&origin=2015-13-00.csv';
+    request(app)
+      .delete('/api/v1/imports/summaries' + urlParams)
+      .expect(200)
+      .expect("content-type", /json/)
+      .end(function(err, response) {
+        if (err) throw err;
+        response.status.should.equal(200);
+        response.body.should.startWith('OK - Deleted');
+        done();
+      });
+
   });
 
   it('DELETE: Attempted deletion of missing summary log entry returns 404 response code and JSON "OK".', function(done) {
 
+    urlParams = '?type=user_import&source=teenlife&origin=2015-13-00.csv';
+    request(app)
+      .delete('/api/v1/imports/summaries' + urlParams)
+      .expect(404)
+      .expect("content-type", /json/)
+      .end(function(err, response) {
+        if (err) throw err;
+        response.status.should.equal(404);
+        response.body.should.startWith('OK - No documents found');
+        done();
+      });
+
   });
 
   it('GET: Lookup of missing import summary log entry returns 404 response code.', function(done) {
+
+    urlParams = '?type=user_import&source=teenlife';
+    request(app)
+      .get('/api/v1/imports/summaries' + urlParams)
+      .expect(404)
+      .expect("content-type", /json/)
+      .end(function(err, response) {
+        if (err) throw err;
+        response.status.should.equal(404);
+        response.body.should.startWith('OK - No match found');
+        done();
+      });
 
   });
 });

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -35,7 +35,6 @@ describe('Requests to the root (/api) path', function() {
       .get('/api')
       .expect("content-type", /json/, done)
   });
-
 });
 
 /**
@@ -56,7 +55,6 @@ describe('Requests to v1 root (/api/v1) path', function() {
       .get('/api/v1')
       .expect("content-type", /json/, done)
   });
-
 });
 
 /**
@@ -181,7 +179,6 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
         done();
       });
   });
-
 });
 
 /**
@@ -227,27 +224,21 @@ describe('Requests to v1 imports (/api/v1/imports/summaries) path', function() {
       });
   });
 
-  // @todo
-  /*
   it('GET: Lookup import log summary entry returns 200 response code and expected content.', function(done) {
 
   });
-  */
 
-  // @todo
-  /*
   it('DELETE: Import summary log entry returns 200 response code and expected OK response.', function(done) {
 
   });
-  */
 
-  // @todo
-  /*
+  it('DELETE: Attempted deletion of missing summary log entry returns 404 response code and JSON "OK".', function(done) {
+
+  });
+
   it('GET: Lookup of missing import summary log entry returns 404 response code.', function(done) {
 
   });
-  */
-
 });
 
 /**
@@ -312,7 +303,6 @@ describe('Requests to v1 imports (/api/v1/user/activity) path', function() {
 
   });
   */
-
 });
 
 /**
@@ -507,5 +497,4 @@ describe('Requests to v1 imports (/api/v1/user/transactional) path', function() 
         done();
       });
   });
-
 });

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -203,7 +203,7 @@ describe('Requests to v1 imports (/api/v1/imports/summaries) path', function() {
 
   it('POST: Addition of import log summary entry returns 201 response code and "OK" message.', function(done) {
 
-    urlParams = '?source=niche&type=user_import';
+    urlParams = '?source=teenlife&type=user_import';
     request(app)
       .post('/api/v1/imports/summaries' + urlParams)
       .send({
@@ -226,6 +226,22 @@ describe('Requests to v1 imports (/api/v1/imports/summaries) path', function() {
 
   it('GET: Lookup import log summary entry returns 200 response code and expected content.', function(done) {
 
+    urlParams = '?type=user_import&source=teenlife';
+    request(app)
+      .get('/api/v1/imports/summaries' + urlParams)
+      .expect(200)
+      .expect("content-type", /json/)
+      .end(function(err, res) {
+        if (err) throw err;
+        res.status.should.equal(200);
+        res.body[0].should.have.property('logged_date');
+        res.body[0].target_CSV_file.should.equal("2015-13-00.csv");
+        res.body[0].signup_count.should.equal(69);
+        res.body[0].skipped.should.equal(1);
+        res.body[0].source.should.equal("teenlife");
+        res.body[0].log_type.should.equal("user_import");
+        done();
+      });
   });
 
   it('DELETE: Import summary log entry returns 200 response code and expected OK response.', function(done) {


### PR DESCRIPTION
Fixes #11 

Adjustments to application to update endpoint logic based on test development.
- `/api/v1/imports/summaries`:
  - [x] it('GET: Lookup of missing import summary log entries returns 404 response code.'
  - [x] it('POST: Import log summary entry returns 200 response code and OK message.'
  - [x] it('GET: Lookup of summary import log entry returns 200 response code. Returned data is formatted as expected.'
  - [x] it('DELETE: Test summary log entry returns 200 response code.'
  - [x] it('DELETE: Non existing test summary log entry returns 404 response code.'
  - [x] it('GET: Lookup of deleted import summary log entry returns 404 response code.'
