### PR TITLE
Issue23 wildcards in get imports

### DIFF
--- a/mb-logging-api/lib/user-import.js
+++ b/mb-logging-api/lib/user-import.js
@@ -123,6 +123,13 @@ UserImport.prototype.get = function(req, res) {
     var targetEndDate = new Date(req.param("end_date"));
   }
 
+  if (req.query.origin_start.indexOf('*') === -1 && req.query.origin_end === undefined) {
+    var originCondition = req.query.origin_start;
+  }
+  else {
+    var originCondition = {$gte : req.query.origin_start, $lt : req.query.origin_end};
+  }
+
   var data = {
     request: req,
     response: res
@@ -132,7 +139,7 @@ UserImport.prototype.get = function(req, res) {
     $and : [
       { 'logged_date' : {$gte : targetStartDate, $lte : targetEndDate} },
       { 'source' : req.query.source },
-      { 'origin.name' : req.query.origin }
+      { 'origin.name' : originCondition }
     ]},
     function (err, docs) {
       if (err) {

--- a/mb-logging-api/routes/routes.js
+++ b/mb-logging-api/routes/routes.js
@@ -99,8 +99,8 @@ module.exports = (function() {
     .get(function(req, res) {
       if (req.query.type === undefined ||
           req.query.source === undefined ||
-          req.query.origin === undefined) {
-        res.status(400).json('ERROR, missing required values. GET /api/v1/import, type, source and origin not specified.');
+          req.query.origin_start === undefined) {
+        res.status(400).json('ERROR, missing required values. GET /api/v1/import : type, source and origin_start not specified.');
       }
       else {
         if (req.query.source.toLowerCase() === 'niche') {

--- a/mb-logging-api/test.js
+++ b/mb-logging-api/test.js
@@ -112,7 +112,7 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
 
   it('GET: Lookup Niche import log entries returns 200 response code and expected content.', function(done) {
 
-    urlParams = '?type=user_import&source=niche&origin=Niche-01-01-16.csv';
+    urlParams = '?type=user_import&source=niche&origin_start=Niche-01-01-16.csv';
     request(app)
       .get('/api/v1/imports' + urlParams)
       .expect(200)
@@ -167,7 +167,7 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
 
   it('GET: Lookup of missing Niche import log entries returns 404 response code.', function(done) {
 
-    urlParams = '?type=user_import&source=niche&origin=Niche-01-01-16.csv';
+    urlParams = '?type=user_import&source=niche&origin_start=Niche-01-01-16.csv';
     request(app)
       .get('/api/v1/imports' + urlParams)
       .expect(404)
@@ -209,7 +209,7 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
 
   it('GET: Lookup After School import log entries returns 200 response code and expected content.', function(done) {
 
-    urlParams = '?type=user_import&source=afterschool&origin=AfterSchool-01-01-16.csv';
+    urlParams = '?type=user_import&source=afterschool&origin_start=AfterSchool-01-01-16.csv';
     request(app)
       .get('/api/v1/imports' + urlParams)
       .expect(200)
@@ -265,7 +265,7 @@ describe('Requests to v1 imports (/api/v1/imports) path', function() {
 
   it('GET: Lookup of missing After School import log entries returns 404 response code.', function(done) {
 
-    urlParams = '?type=user_import&source=afterschool&origin=AfterSchool-01-01-16.csv';
+    urlParams = '?type=user_import&source=afterschool&origin_start=AfterSchool-01-01-16.csv';
     request(app)
       .get('/api/v1/imports' + urlParams)
       .expect(404)


### PR DESCRIPTION
Fixes #23 

Adds `origin_start` and `origin_end` to `/v1/imports` GET requests to allow for wildcards "`*`" in the value which will result in a possible array of return values. 
